### PR TITLE
Loosen type check on parameter act

### DIFF
--- a/CeAccess.php
+++ b/CeAccess.php
@@ -49,7 +49,7 @@ class CeAccess
             $GLOBALS['TL_DCA']['tl_content']['palettes']['default'] = $GLOBALS['TL_DCA']['tl_content']['palettes'][@key(@current($arrConfig))];
         }
 
-        if (\Input::get('act') && !in_array(\Input::get('act'), array('', 'select'))) {
+        if (!empty(\Input::get('act')) && (string) \Input::get('act') !== '' && (string) \Input::get('act') !== 'select') {
             $GLOBALS['TL_CTE'] = $arrConfig;
             $session = \Session::getInstance()->getData();
 
@@ -83,7 +83,7 @@ class CeAccess
             \Session::getInstance()->setData($session);
 
             if (!in_array(\Input::get('act'), array('show', 'create', 'select', 'editAll'), true)
-                && !(\Input::get('act') == 'paste' && \Input::get('mode') == 'create')
+                && !((string) \Input::get('act') === 'paste' && (string) \Input::get('mode') === 'create')
             ) {
                 $objElement = \Database::getInstance()
                     ->prepare('SELECT type FROM tl_content WHERE id=?')

--- a/CeAccess.php
+++ b/CeAccess.php
@@ -49,7 +49,7 @@ class CeAccess
             $GLOBALS['TL_DCA']['tl_content']['palettes']['default'] = $GLOBALS['TL_DCA']['tl_content']['palettes'][@key(@current($arrConfig))];
         }
 
-        if (\Input::get('act') !== '' && \Input::get('act') !== 'select') {
+        if (\Input::get('act') && !in_array(\Input::get('act'), array('', 'select'))) {
             $GLOBALS['TL_CTE'] = $arrConfig;
             $session = \Session::getInstance()->getData();
 
@@ -83,7 +83,7 @@ class CeAccess
             \Session::getInstance()->setData($session);
 
             if (!in_array(\Input::get('act'), array('show', 'create', 'select', 'editAll'), true)
-                && !(\Input::get('act') === 'paste' && \Input::get('mode') === 'create')
+                && !(\Input::get('act') == 'paste' && \Input::get('mode') == 'create')
             ) {
                 $objElement = \Database::getInstance()
                     ->prepare('SELECT type FROM tl_content WHERE id=?')

--- a/CeAccess.php
+++ b/CeAccess.php
@@ -21,6 +21,8 @@ class CeAccess
         if (\BackendUser::getInstance()->isAdmin) {
             return;
         }
+log_message('type: ' . gettype($_GET['acts']), 'ceaccess.log');
+log_message('value: ' . $_GET['acts'], 'ceaccess.log');
 
         $arrElements = deserialize(\BackendUser::getInstance()->elements, true);
         $arrKeys = array_flip($arrElements);
@@ -49,7 +51,7 @@ class CeAccess
             $GLOBALS['TL_DCA']['tl_content']['palettes']['default'] = $GLOBALS['TL_DCA']['tl_content']['palettes'][@key(@current($arrConfig))];
         }
 
-        if (!empty(\Input::get('act')) && (string) \Input::get('act') !== '' && (string) \Input::get('act') !== 'select') {
+        if (\Input::get('act') && \Input::get('act') !== '' && \Input::get('act') !== 'select') {
             $GLOBALS['TL_CTE'] = $arrConfig;
             $session = \Session::getInstance()->getData();
 
@@ -83,7 +85,7 @@ class CeAccess
             \Session::getInstance()->setData($session);
 
             if (!in_array(\Input::get('act'), array('show', 'create', 'select', 'editAll'), true)
-                && !((string) \Input::get('act') === 'paste' && (string) \Input::get('mode') === 'create')
+                && !(\Input::get('act') === 'paste' && \Input::get('mode') === 'create')
             ) {
                 $objElement = \Database::getInstance()
                     ->prepare('SELECT type FROM tl_content WHERE id=?')

--- a/CeAccess.php
+++ b/CeAccess.php
@@ -49,7 +49,7 @@ class CeAccess
             $GLOBALS['TL_DCA']['tl_content']['palettes']['default'] = $GLOBALS['TL_DCA']['tl_content']['palettes'][@key(@current($arrConfig))];
         }
 
-        if (\Input::get('act') && \Input::get('act') !== '' && \Input::get('act') !== 'select') {
+        if ((string) \Input::get('act') !== '' && \Input::get('act') !== 'select') {
             $GLOBALS['TL_CTE'] = $arrConfig;
             $session = \Session::getInstance()->getData();
 

--- a/CeAccess.php
+++ b/CeAccess.php
@@ -21,8 +21,6 @@ class CeAccess
         if (\BackendUser::getInstance()->isAdmin) {
             return;
         }
-log_message('type: ' . gettype($_GET['acts']), 'ceaccess.log');
-log_message('value: ' . $_GET['acts'], 'ceaccess.log');
 
         $arrElements = deserialize(\BackendUser::getInstance()->elements, true);
         $arrKeys = array_flip($arrElements);


### PR DESCRIPTION
Hi Andreas!

Highly appreciating an heavily using ce-access we ran into this:

Access to an article in some cases is denied by mistake and redirects to error message caused by strict comparison on parameter `'act'`.  

Specifically:
- if `tl_content` contains a record with the same ID as the article to be listed with its content elements and 
- current user is not allowed to edit the specific type of this unconnected content element.

This happens since param `'act'` is now validated in a negated strict comparison and the following filtering block and final redirect exit will be applied when listing the content elements of an article (`'act' == NULL`, and therefore not a `string`). For this request `$dc->id` contains the ID of an article and must not be compared to IDs of table `tl_content`.

Since `Input::get` always returns either `string` or `NULL` I would propose to discard strict comparison later on as well.

Regards
Martin