### PR TITLE
Update CeAccess.php

### DIFF
--- a/CeAccess.php
+++ b/CeAccess.php
@@ -84,6 +84,7 @@ class CeAccess
 
             if (!in_array(\Input::get('act'), array('show', 'create', 'select', 'editAll'), true)
                 && !(\Input::get('act') === 'paste' && \Input::get('mode') === 'create')
+                && $dc->ptable == 'tl_content'
             ) {
                 $objElement = \Database::getInstance()
                     ->prepare('SELECT type FROM tl_content WHERE id=?')


### PR DESCRIPTION
Make sure the actual element is an content element, because if ptable = 'tl_arcticle' and an element with the $dc->id exists in tl_content and has an content-element-type which is restricted, a wrong error message is risen in system log an the article could not be edited